### PR TITLE
prevent mkdir to fail in case of existing directory

### DIFF
--- a/examples/adaptation/scripts/prepare_experiments.sh
+++ b/examples/adaptation/scripts/prepare_experiments.sh
@@ -15,7 +15,7 @@ echo "[*] Downloading ImageNet aux data..."
 
 # Prepare lmdb databases for the Office dataset.
 echo "[*] Preparing datasets..."
-mkdir ./examples/adaptation/datasets
+mkdir -p ./examples/adaptation/datasets
 for DOMAIN in amazon webcam dslr; do
     python ./examples/adaptation/scripts/convert_data.py \
         -s $OFFICE_DIR/domain_adaptation_images/ \

--- a/examples/adaptation/scripts/prepare_experiments.sh
+++ b/examples/adaptation/scripts/prepare_experiments.sh
@@ -7,11 +7,11 @@ cd $ROOT_DIR
 
 # Download AlexNet reference model.
 echo "[*] Downloading AlexNet reference model..."
-python ./scripts/download_model_binary.py ./models/bvlc_alexnet >/dev/null 2>/dev/null
+python ./scripts/download_model_binary.py ./models/bvlc_alexnet >/dev/null
 
 # Download ImageNet aux data.
 echo "[*] Downloading ImageNet aux data..."
-./data/ilsvrc12/get_ilsvrc_aux.sh >/dev/null 2>/dev/null
+./data/ilsvrc12/get_ilsvrc_aux.sh >/dev/null
 
 # Prepare lmdb databases for the Office dataset.
 echo "[*] Preparing datasets..."
@@ -20,7 +20,7 @@ for DOMAIN in amazon webcam dslr; do
     python ./examples/adaptation/scripts/convert_data.py \
         -s $OFFICE_DIR/domain_adaptation_images/ \
         -t ./examples/adaptation/datasets/ \
-        -d $DOMAIN -i 1 >/dev/null 2>/dev/null
+        -d $DOMAIN -i 1 >/dev/null
 done
 
 # Prepare directories for the experiments.
@@ -32,5 +32,5 @@ for MODE in amazon_to_webcam dslr_to_webcam webcam_to_dslr; do
         -d ./examples/adaptation/datasets \
         -a ./models/bvlc_alexnet/bvlc_alexnet.caffemodel \
         -i ./data/ilsvrc12/imagenet_mean.binaryproto \
-        -p ./examples/adaptation/protos >/dev/null 2>/dev/null
+        -p ./examples/adaptation/protos >/dev/null
 done


### PR DESCRIPTION
in case the prepare script is called a second time (e.g. with a different office_dir) mkdir should not complain about the fact that "examples/adaptation/datasets" already exists
